### PR TITLE
feat(backend): add TestRun entity, repository, TestRunController, and integration tests

### DIFF
--- a/backend/src/main/java/com/example/networkperf/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/networkperf/backend/config/SecurityConfig.java
@@ -1,0 +1,24 @@
+package com.example.networkperf.backend.config;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    
+    @Bean
+  SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                                .requestMatchers("/actuator/health").permitAll()
+                                .anyRequest().authenticated()
+                )
+                .httpBasic(withDefaults()); 
+    return http.build();
+  }
+}

--- a/backend/src/main/java/com/example/networkperf/backend/controller/TestRunController.java
+++ b/backend/src/main/java/com/example/networkperf/backend/controller/TestRunController.java
@@ -1,0 +1,27 @@
+package com.example.networkperf.backend.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.networkperf.backend.model.TestRun;
+import com.example.networkperf.backend.repository.TestRunRepository;
+
+@RestController
+@RequestMapping("/api/tests")
+public class TestRunController {
+
+    private final TestRunRepository repository;
+
+    public TestRunController(TestRunRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping
+    public List<TestRun> getAllRuns() {
+        return repository.findAll();
+    }
+    
+}

--- a/backend/src/main/java/com/example/networkperf/backend/model/TestRun.java
+++ b/backend/src/main/java/com/example/networkperf/backend/model/TestRun.java
@@ -1,0 +1,78 @@
+package com.example.networkperf.backend.model;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "test_runs")
+public class TestRun {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Instant timestamp;
+
+    @Column(nullable = false)
+    private double latencyMs;
+
+    @Column(nullable = false)
+    private double packetLossPct;
+
+    @Column(nullable = false)
+    private double downloadMbps;
+
+    @Column(nullable = false)
+    private double uploadMbps;
+
+    public Long getId() {
+        return id;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public double getLatencyMs() {
+        return latencyMs;
+    }
+
+    public void setLatencyMs(double latencyMs) {
+        this.latencyMs = latencyMs;
+    }
+
+    public double getPacketLossPct() {
+        return packetLossPct;
+    }
+
+    public void setPacketLossPct(double packetLossPct) {
+        this.packetLossPct = packetLossPct;
+    }
+
+    public double getDownloadMbps() {
+        return downloadMbps;
+    }
+
+    public void setDownloadMbps(double downloadMbps) {
+        this.downloadMbps = downloadMbps;
+    }
+
+    public double getUploadMbps() {
+        return uploadMbps;
+    }
+
+    public void setUploadMbps(double uploadMbps) {
+        this.uploadMbps = uploadMbps;
+    }
+}

--- a/backend/src/main/java/com/example/networkperf/backend/repository/TestRunRepository.java
+++ b/backend/src/main/java/com/example/networkperf/backend/repository/TestRunRepository.java
@@ -1,0 +1,9 @@
+package com.example.networkperf.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.networkperf.backend.model.TestRun;
+
+public interface TestRunRepository extends JpaRepository<TestRun, Long> {
+    
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,12 +8,18 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+  security:
+    user:
+      name: ${API_USER:admin}
+      password: ${API_PASSWORD:admin}
 
 management:
   endpoints:
     web:
       exposure:
         include: health,info
+
+
 
 # placeholder cron schedule for ping runner service
 app:

--- a/backend/src/test/java/com/example/networkperf/backend/TestRunControllerTests.java
+++ b/backend/src/test/java/com/example/networkperf/backend/TestRunControllerTests.java
@@ -1,0 +1,72 @@
+package com.example.networkperf.backend;
+
+import com.example.networkperf.backend.model.TestRun;
+import com.example.networkperf.backend.repository.TestRunRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Instant;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+public class TestRunControllerTests {
+    
+    @Container
+    static PostgreSQLContainer<?> pg = new PostgreSQLContainer<>("postgres:14")
+        .withDatabaseName("test")
+        .withUsername("postgres")
+        .withPassword("postgres");
+
+    @DynamicPropertySource
+    static void overrideProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", pg::getJdbcUrl);
+        registry.add("spring.datasource.username", pg::getUsername);
+        registry.add("spring.datasource.password", pg::getPassword);
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TestRunRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        repo.deleteAll();
+        TestRun run = new TestRun();
+        run.setTimestamp(Instant.parse("2025-06-22T11:00:00Z"));
+        run.setLatencyMs(10.0);
+        run.setPacketLossPct(0.0);
+        run.setDownloadMbps(50.0);
+        run.setUploadMbps(10.0);
+        repo.save(run);
+    }
+
+    @Test
+    void getAllRuns_returnsJsonArray() throws Exception {
+        mockMvc.perform(get("/api/tests")
+            .with(httpBasic("admin", "admin"))
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$", hasSize(1)))
+            .andExpect(jsonPath("$[0].latencyMs", is(10.0)))
+            .andExpect(jsonPath("$[0].downloadMbps", is(50.0)));
+        }       
+}

--- a/backend/src/test/java/com/example/networkperf/backend/TestRunRepositoryTests.java
+++ b/backend/src/test/java/com/example/networkperf/backend/TestRunRepositoryTests.java
@@ -1,0 +1,57 @@
+package com.example.networkperf.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.example.networkperf.backend.model.TestRun;
+import com.example.networkperf.backend.repository.TestRunRepository;
+
+@DataJpaTest
+@Testcontainers
+public class TestRunRepositoryTests {
+    
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:14")
+        .withDatabaseName("test")
+        .withUsername("postgres")
+        .withPassword("postgres");
+
+    @DynamicPropertySource
+    static void pgProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private TestRunRepository repository;
+
+    @Test
+    void saveAndFind() {
+        TestRun run = new TestRun();
+        run.setTimestamp(Instant.now());
+        run.setLatencyMs(12.3);
+        run.setPacketLossPct(0.5);
+        run.setDownloadMbps(100.0);
+        run.setUploadMbps(20.0);
+
+        repository.save(run);
+
+        List<TestRun> all = repository.findAll();
+        assertThat(all).hasSize(1);
+        TestRun fetched = all.get(0);
+        assertThat(fetched.getLatencyMs()).isEqualTo(12.3);
+        assertThat(fetched.getDownloadMbps()).isEqualTo(100.0);
+    }
+}


### PR DESCRIPTION
-Added TestRun JPA entity (fields: id, timestamp, latencyMs, packetLossPct, downloadMbps, uploadMbps)

-Created TestRunRepository extending JpaRepository<TestRun, Long>
-Wrote TestRunRepositoryTests using @DataJpaTest + Testcontainers to verify save and fetch

-Added TestRunController, exposing GET /api/tests -> returns all runs as JSON

-Added SecurityConfig to enable HTTP Basic auth (user/pass in application.yml)

-Updated TestRunControllerTests to assert GET endpoint behavior